### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-starter-task-spark-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
+++ b/spring-cloud-starter-task-spark-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
@@ -27,7 +27,7 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 
 /*
- * NOTE: Copied from the Apache Spark (http://spark.apache.org/) source code since
+ * NOTE: Copied from the Apache Spark (https://spark.apache.org/) source code since
  * this class is not available in the Maven Central repo.
  */
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://spark.apache.org/ with 1 occurrences migrated to:  
  https://spark.apache.org/ ([https](https://spark.apache.org/) result 200).